### PR TITLE
Explicitly initialize to undefined

### DIFF
--- a/gps.ts
+++ b/gps.ts
@@ -44,7 +44,7 @@ namespace gps {
 
         for (let i = 0; i < input.length; ++i) {
             const code = input.charCodeAt(i) | lowerCaseMask;
-            let val: number;
+            let val: number = undefined;
 
             if (code >= numberOffset && code < numberOffset + 10)
                 val = code - numberOffset;


### PR DESCRIPTION
Looks like variables in loops maintain value through iterations of loop - see https://github.com/Microsoft/pxt-arcade/issues/535 @sabas1080 